### PR TITLE
fixed name and type for html control, improved textarea styling

### DIFF
--- a/src/app/pie-graph/page.tsx
+++ b/src/app/pie-graph/page.tsx
@@ -39,7 +39,7 @@ export default function Page() {
 						description={"Renders labels on the pie chart"}
 					/>
 				</Control>
-				<Control name="HTML" type="text">
+				<Control name="children" type="ReactNode">
 					<HTMLControl 
 						html={pie.children?.toString() ?? ""} 
 						onChange={(children) => setPiePartial({ children })} />

--- a/src/components/Docs/Control/components/HTMLControl/HTMLControl.tsx
+++ b/src/components/Docs/Control/components/HTMLControl/HTMLControl.tsx
@@ -6,7 +6,7 @@ type Props = {
 export const HTMLControl = ({ html, onChange = Object }: Props) => {
 	return (
 		<label className={"flex items-center cursor-pointer"}>
-            <textarea className={"[resize:both]"} value={html} onChange={(e) => onChange(e.target.value)}></textarea>
+            <textarea className={"[resize:both] border-[1px] border-black min-w-60"} value={html} onChange={(e) => onChange(e.target.value)} placeholder="I.E <div>HELLO WORLD</div>"></textarea>
 		</label>
 	);
 };


### PR DESCRIPTION
This pr changes control header name for HTMLControl in PieGraph to 'children' and type to 'ReactNode'. It also fixes some styling on the textarea, adding a border to make it visible, wider and adds a placeholder

![image](https://github.com/user-attachments/assets/cf44ccc1-9be7-4d43-a5fb-e0af633f2425)
