### PR TITLE
loading animation for pie graph during lightmode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,3 +38,18 @@
   }
 
 }
+
+
+@keyframes pie-graph-loading {
+	0% { fill: #a7a7a7; }
+	30% { fill: #cdcdcd; }
+	60% { fill: #a7a7a7; }
+	100% { fill: #a7a7a7; }
+}
+
+@keyframes dark-pie-graph-loading {
+	0% { fill: #2d2d2d; }
+	30% { fill: #3c3c3c; }
+	60% { fill: #2d2d2d; }
+	100% { fill: #2d2d2d; }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,18 +38,3 @@
   }
 
 }
-
-
-@keyframes pie-graph-loading {
-	0% { fill: #a7a7a7; }
-	30% { fill: #cdcdcd; }
-	60% { fill: #a7a7a7; }
-	100% { fill: #a7a7a7; }
-}
-
-@keyframes dark-pie-graph-loading {
-	0% { fill: #2d2d2d; }
-	30% { fill: #3c3c3c; }
-	60% { fill: #2d2d2d; }
-	100% { fill: #2d2d2d; }
-}

--- a/src/components/PieGraph/PieGraph.tsx
+++ b/src/components/PieGraph/PieGraph.tsx
@@ -32,17 +32,11 @@ export const PieGraph = ({ donut, labels = true, loading, children }: Props) => 
 	if (loading) {
 		return (
 			<svg viewBox={`0 0 3000 3000`} role="status" aria-busy={loading} className={"h-full w-full"}>
-				<path d={PathUtils.circleArc(X_SCALE / 2, Y_SCALE / 2, PIE_RADIUS)}>
-					<animate
-						attributeName="fill"
-						values="#2d2d2d; #3c3c3c; #2d2d2d; #2d2d2d;"
-						dur="2s"
-						repeatCount="indefinite"
-						calcMode="spline"
-						keyTimes="0; 0.3; 0.6; 1"
-						keySplines="0.15 0.25 0.25 0.15; 0.15 0.25 0.25 0.15; 0 0 0 0"
-					/>
-				</path>
+				<path d={PathUtils.circleArc(X_SCALE / 2, Y_SCALE / 2, PIE_RADIUS)} 
+					className="animate-[pie-graph-loading_ease-in-out_2s_infinite]
+							dark:animate-[dark-pie-graph-loading_ease-in-out_2s_infinite]">
+				</path> 
+
 				{donut && <path className={""} d={PathUtils.circleArc(X_SCALE / 2, Y_SCALE / 2, PIE_RADIUS * 0.65)} />}
 			</svg>
 		);

--- a/src/components/PieGraph/PieGraph.tsx
+++ b/src/components/PieGraph/PieGraph.tsx
@@ -32,11 +32,17 @@ export const PieGraph = ({ donut, labels = true, loading, children }: Props) => 
 	if (loading) {
 		return (
 			<svg viewBox={`0 0 3000 3000`} role="status" aria-busy={loading} className={"h-full w-full"}>
-				<path d={PathUtils.circleArc(X_SCALE / 2, Y_SCALE / 2, PIE_RADIUS)} 
-					className="animate-[pie-graph-loading_ease-in-out_2s_infinite]
-							dark:animate-[dark-pie-graph-loading_ease-in-out_2s_infinite]">
-				</path> 
-
+				<path d={PathUtils.circleArc(X_SCALE / 2, Y_SCALE / 2, PIE_RADIUS)} className={"[filter:brightness(300%)] dark:[filter:brightness(100%)]"}>
+					<animate
+						attributeName="fill"
+						values="#2d2d2d; #3c3c3c; #2d2d2d; #2d2d2d;"
+						dur="2s"
+						repeatCount="indefinite"
+						calcMode="spline"
+						keyTimes="0; 0.3; 0.6; 1"
+						keySplines="0.15 0.25 0.25 0.15; 0.15 0.25 0.25 0.15; 0 0 0 0"
+					/>
+				</path>
 				{donut && <path className={""} d={PathUtils.circleArc(X_SCALE / 2, Y_SCALE / 2, PIE_RADIUS * 0.65)} />}
 			</svg>
 		);

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -12,6 +12,7 @@ export function ThemeToggle() {
 		setTheme(newTheme);
 		localStorage.setItem("nano-theme", newTheme);
 		document.documentElement.setAttribute("data-theme", newTheme);
+		document.documentElement.classList.toggle('dark', newTheme == "dark")
 	};
 
 	useLayoutEffect(() => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,5 +30,5 @@ export default {
 		},
 	},
 	plugins: [],
-	darkMode: "class",
+	darkMode: "selector",
 };


### PR DESCRIPTION
This pr implements a lighter colored animation for pie graph in its loading state. I implemented this by creating 2 different CSS keyframe animations for each theme and using tailwinds dark selectors we choose which one depending on current theme. Also implemented support for dark selectors by updating the tailwindcss config and adding the 'dark' class to root in ThemeToggle.tsx on toggle.